### PR TITLE
Add the roadmap auto commenter to this repository

### DIFF
--- a/.github/workflows/roadmap-auto-commenter.yml
+++ b/.github/workflows/roadmap-auto-commenter.yml
@@ -1,0 +1,19 @@
+# When modifying this file, make sure to pass on the update to all repositories.  A tool like https://github.com/gruntwork-io/git-xargs may be useful for this.
+
+# WARNING: This workflow is sometimes triggered by pull_request_target and so will always run automatically on pull requests made by anyone.  Do not do any sort of processing of user input, such as checking out code.
+
+name: Roadmap Auto Commenter
+on:
+  issues:
+    types:
+      - opened
+  pull_request_target:
+    types:
+      - opened
+
+jobs:
+  call_reusable_roadmap_auto_commenter:
+    permissions:
+      issues: write
+      pull-requests: write
+    uses: Hubs-Foundation/.github/.github/workflows/reusable-roadmap-auto-commenter.yml@main


### PR DESCRIPTION
## What?
Adds a workflow that calls the reusable roadmap auto commenter workflow when issues or pull requests are opened.

## Why?
To activate the roadmap auto commenter for this repository.

## Examples
See: https://github.com/Hubs-Foundation/.github/pull/11

## How to test
See the testing instructions in the companion PR: https://github.com/Hubs-Foundation/.github/pull/11

## Documentation of functionality
Currently, this is fully automatic with no configuration options and it is for the Hubs Foundation's use only (so not appropriate to put in the Hubs Docs).  This helps to apply the roadmap policy.  In light of all this, I don't think any additional documentation is needed at present.

## Limitations
None known.

## Alternative implementations considered
None.

## Open questions
None.

## Additional details or related context
Reusable roadmap auto commenter companion PR: https://github.com/Hubs-Foundation/.github/pull/11

This PR was created by https://github.com/gruntwork-io/git-xargs and should be functionally identical to https://github.com/Hubs-Foundation/.github/pull/12